### PR TITLE
Fix Exception "The table name must not be empty"

### DIFF
--- a/src/BackendIntegration/Dca.php
+++ b/src/BackendIntegration/Dca.php
@@ -74,6 +74,7 @@ class Dca
             $template->rows           = $rows;
             $template->fields         = $dcaWizard->fields;
             $template->showOperations = $dcaWizard->showOperations;
+            $template->foreignTable = 'tl_iso_stock';
 
             if ($dcaWizard->showOperations) {
                 $template->operations = $dcaWizard->getActiveRowOperations();


### PR DESCRIPTION
The error occurs with `terminal42/dcawizard > 2.4.0` because of [this change](https://github.com/terminal42/contao-dcawizard/commit/90874122908ca8bc0bcc2b0f5548406a6a9a163b#diff-eb26c39902856ce72ee3ec65af35ed9d).